### PR TITLE
Normalize phone numbers before formatting

### DIFF
--- a/src/Support/PhoneNumber.php
+++ b/src/Support/PhoneNumber.php
@@ -18,6 +18,8 @@ class PhoneNumber
 
         $phoneNumber = (string) $phoneNumber;
 
+        $phoneNumber = self::normalize($phoneNumber) ?? $phoneNumber;
+
         if (strlen($phoneNumber) !== 10) {
             return $phoneNumber;
         }

--- a/tests/Support/PhoneNumberTest.php
+++ b/tests/Support/PhoneNumberTest.php
@@ -12,6 +12,11 @@ class PhoneNumberTest extends TestCase
         $this->assertSame('(123) 456-7890', PhoneNumber::format('1234567890'));
     }
 
+    public function test_format_normalizes_input_before_formatting(): void
+    {
+        $this->assertSame('(123) 456-7890', PhoneNumber::format('(123) 456-7890'));
+    }
+
     public function test_format_returns_null_for_empty_input(): void
     {
         $this->assertNull(PhoneNumber::format(null));


### PR DESCRIPTION
## Summary
- ensure `PhoneNumber::format` normalizes input before length checks
- test that formatted numbers are normalized correctly

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68ab9ab7c2b88325be6209cd88f684a4