### PR TITLE
Sort exported enums alphabetically for deterministic index

### DIFF
--- a/src/Console/Commands/ExportEnumsCommand.php
+++ b/src/Console/Commands/ExportEnumsCommand.php
@@ -93,6 +93,8 @@ class ExportEnumsCommand extends Command
             }
         }
 
+        usort($exported, fn (array $a, array $b) => strcmp($a['path'], $b['path']));
+
         File::ensureDirectoryExists($outputPath);
         $indexFile = $outputPath.DIRECTORY_SEPARATOR.'index.'.$format;
         $index = $banner ? $banner."\n" : '';

--- a/tests/Console/ExportEnumsCommandTest.php
+++ b/tests/Console/ExportEnumsCommandTest.php
@@ -71,8 +71,15 @@ PHP);
 
         $this->assertStringContainsString('export enum Status', File::get($statusFile));
         $this->assertStringContainsString('export enum InvoiceStatus', File::get($invoiceFile));
-        $this->assertStringContainsString("export { Status } from './Status';", File::get($indexFile));
-        $this->assertStringContainsString("export { InvoiceStatus } from './Billing/InvoiceStatus';", File::get($indexFile));
+
+        $indexContent = File::get($indexFile);
+        $expectedIndex = implode(PHP_EOL, [
+            '// test',
+            "export { InvoiceStatus } from './Billing/InvoiceStatus';",
+            "export { Status } from './Status';",
+            '',
+        ]);
+        $this->assertSame($expectedIndex, $indexContent);
     }
 }
 


### PR DESCRIPTION
## Summary
- Sort exported enum list by path for deterministic index generation
- Add test verifying index file exports enums in alphabetical order

## Testing
- `./vendor/bin/pint` *(fails: No such file or directory)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68ab9ac68ec083258961680fc168cfa4