### PR TITLE
Handle duplicate enum names in exporter

### DIFF
--- a/docs/enum-exporter.md
+++ b/docs/enum-exporter.md
@@ -22,6 +22,14 @@ php artisan atlas:export-enums
 
 The command scans the configured enum paths and writes matching files to `resources/js/enums` (overridable via config). Each PHP enum is converted into a corresponding TypeScript/JavaScript enum and re-exported through an index file for easy imports.
 
+If multiple enums share the same class name in different namespaces, the index file automatically aliases duplicates using their path segments to avoid export conflicts. Repeated segments that already appear in the class name are omitted to keep aliases concise:
+
+```ts
+// resources/js/enums/index.ts
+export { ActionStatus } from './Action/ActionStatus';
+export { ActionStatus as ActionWorkerStatus } from './Action/Worker/ActionStatus';
+```
+
 Define a PHP enum:
 
 ```php


### PR DESCRIPTION
## Summary
- omit repeated segments when aliasing duplicate enums to keep index exports concise
- test duplicate enum names and ensure index aliases skip redundant namespace segments
- document alias trimming behavior in enum exporter docs

## Testing
- `$(composer global config bin-dir --absolute)/pint src/Console/Commands/ExportEnumsCommand.php tests/Console/ExportEnumsCommandTest.php docs/enum-exporter.md`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68aba0e70f4483258a7788df2ffb6a55