### PR TITLE
Allow models with non-scalar keys

### DIFF
--- a/docs/model-service.md
+++ b/docs/model-service.md
@@ -35,7 +35,7 @@ $service->delete($user);
 - `buildQuery(array $options = [])` – base query method you can extend.
 - `list(array $columns = ['*'], array $options = [])` – retrieve all models.
 - `listPaginated(int $perPage = 15, array $options = [])` – retrieve a paginated list.
-- `find(int|string $id)` – locate a model by its primary key.
+- `find(mixed $id)` – locate a model by its primary key.
 - `create(array $data)` – persist a new model.
 - `update(Model $model, array $data)` – update an existing model.
 - `delete(Model $model)` – remove a model from storage.

--- a/src/Services/ModelService.php
+++ b/src/Services/ModelService.php
@@ -81,9 +81,10 @@ abstract class ModelService
     /**
      * Find a model by primary key.
      *
+     * @param mixed $id
      * @return TModel|null
      */
-    public function find(int|string $id): ?Model
+    public function find(mixed $id): ?Model
     {
         return $this->query()->find($id);
     }

--- a/tests/Services/ModelServiceTest.php
+++ b/tests/Services/ModelServiceTest.php
@@ -93,6 +93,26 @@ class ModelServiceTest extends TestCase
         $this->assertSame(1, $filtered->total());
         $this->assertSame('Alpha', $filtered->first()->name);
     }
+
+    public function test_find_with_string_primary_key(): void
+    {
+        Schema::create('string_widgets', function (Blueprint $table): void {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $service = new class extends ModelService {
+            protected string $model = StringWidget::class;
+        };
+
+        $widget = $service->create(['id' => 'w-1', 'name' => 'Alpha']);
+        $this->assertInstanceOf(StringWidget::class, $widget);
+
+        $found = $service->find('w-1');
+        $this->assertInstanceOf(StringWidget::class, $found);
+        $this->assertSame('Alpha', $found->name);
+    }
 }
 
 class Widget extends Model
@@ -100,4 +120,15 @@ class Widget extends Model
     protected $guarded = [];
 
     protected $table = 'widgets';
+}
+
+class StringWidget extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'string_widgets';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
 }


### PR DESCRIPTION
## Summary
- make ModelService::find accept any primary key type
- document generic `find` signature in model service guide
- test ModelService against a model using string IDs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68aba9051f90832590ea53adfaa5cbae