### PR TITLE
Clear enum export directory before rebuilding

### DIFF
--- a/src/Console/Commands/ExportEnumsCommand.php
+++ b/src/Console/Commands/ExportEnumsCommand.php
@@ -27,6 +27,9 @@ class ExportEnumsCommand extends Command
         $format = $config['format'] ?? 'ts';
         $banner = $config['banner'] ?? '';
 
+        File::deleteDirectory($outputPath);
+        File::ensureDirectoryExists($outputPath);
+
         $exported = [];
 
         foreach ($enumPaths as $path) {

--- a/tests/Console/ExportEnumsCommandTest.php
+++ b/tests/Console/ExportEnumsCommandTest.php
@@ -119,4 +119,18 @@ PHP);
         $this->assertStringContainsString("export { ActionStatus } from './Action/ActionStatus';", $indexContent);
         $this->assertStringContainsString("export { ActionStatus as ActionWorkerStatus } from './Action/Worker/ActionStatus';", $indexContent);
     }
+
+    public function test_clears_output_directory_before_export(): void
+    {
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $invoiceFile = $this->outputDir.'/Billing/InvoiceStatus.ts';
+        $this->assertFileExists($invoiceFile);
+
+        File::delete($this->enumDir.'/Billing/InvoiceStatus.php');
+
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($invoiceFile);
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure enum exports start fresh by deleting and recreating the target directory
- Test enum exporter removes stale files before regenerating

## Testing
- `vendor/bin/pint` *(fails: No such file or directory)*
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68abaabe942883258b8d5c335904eef7