### PR TITLE
Use Carbon for datetime casting

### DIFF
--- a/src/Support/Caster.php
+++ b/src/Support/Caster.php
@@ -2,6 +2,8 @@
 
 namespace Atlas\Laravel\Support;
 
+use Illuminate\Support\Carbon;
+
 class Caster
 {
     /**
@@ -47,13 +49,13 @@ class Caster
      * Cast a value to DateTime.
      *
      * @param mixed $value The value to cast.
-     * @return \DateTime|null The cast DateTime or null on failure.
+     * @return Carbon|null The cast DateTime or null on failure.
      */
-    private static function castToDateTime(mixed $value): ?\DateTime
+    private static function castToDateTime(mixed $value): ?Carbon
     {
         try {
-            return new \DateTime($value);
-        } catch (\Exception) {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
             return null;
         }
     }

--- a/tests/Support/CasterTest.php
+++ b/tests/Support/CasterTest.php
@@ -3,6 +3,7 @@
 namespace Atlas\Laravel\Tests\Support;
 
 use Atlas\Laravel\Support\Caster;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class CasterTest extends TestCase
@@ -18,6 +19,7 @@ class CasterTest extends TestCase
             'birthday' => '2024-01-01',
             'meta' => ['foo' => 'bar'],
             'metaObject' => (object) ['foo' => 'bar'],
+            'meeting' => '2024-01-01 15:00:00 Europe/London',
             'invalidDate' => 'not-a-date',
             'invalidJson' => '{bad json',
         ];
@@ -31,6 +33,7 @@ class CasterTest extends TestCase
             'birthday' => 'datetime',
             'meta' => 'json',
             'metaObject' => 'json',
+            'meeting' => 'datetime',
             'invalidDate' => 'datetime',
             'invalidJson' => 'json',
         ];
@@ -42,7 +45,9 @@ class CasterTest extends TestCase
         $this->assertSame('123', $result['name']);
         $this->assertTrue($result['active']);
         $this->assertSame(['foo' => 'bar'], $result['options']);
-        $this->assertInstanceOf(\DateTime::class, $result['birthday']);
+        $this->assertInstanceOf(Carbon::class, $result['birthday']);
+        $this->assertInstanceOf(Carbon::class, $result['meeting']);
+        $this->assertSame('Europe/London', $result['meeting']->getTimezone()->getName());
         $this->assertSame(['foo' => 'bar'], $result['meta']);
         $this->assertSame(['foo' => 'bar'], $result['metaObject']);
         $this->assertNull($result['invalidDate']);


### PR DESCRIPTION
## Summary
- use `Illuminate\Support\Carbon` for datetime casting and catch `Throwable`
- extend caster tests to ensure Carbon instances and timezone parsing

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68abb38f3504832596128081b4f3c526