### PR TITLE
docs: add Atlas UI and Laravel Template sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Atlas handles the backend foundation and Inertia bridge. It includes tooling for
 - [**Enums**](docs/enum-exporter.md) – export PHP enums for type-safe usage in Vue.
 - [**Model Service**](docs/model-service.md) – base model service providing CRUD scaffolding.
 - [**Support Helpers**](docs/support.md) – lightweight utility classes.
+ 
+## Atlas UI
+
+[Atlas UI](https://github.com/tmarois/atlas-ui) – reusable utilities and PrimeVue components that are complementary to this setup.
+
+## Laravel Template
+
+[Laravel Template](https://github.com/timothymarois/template-laravel-app) – example usage and boilerplate scaffolding is set up in this template.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document Atlas UI utilities and PrimeVue components
- link to a Laravel Template demonstrating example usage and scaffolding

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68abbb8b2bac8325b35f3e49134155cf