### PR TITLE
Add test to ignore non-enum files during export

### DIFF
--- a/tests/Console/ExportEnumsCommandTest.php
+++ b/tests/Console/ExportEnumsCommandTest.php
@@ -133,4 +133,30 @@ PHP);
 
         $this->assertFileDoesNotExist($invoiceFile);
     }
+
+    public function test_ignores_non_enum_files(): void
+    {
+        File::put($this->enumDir.'/note.txt', 'just a file');
+        File::put($this->enumDir.'/Helper.php', <<<'PHP'
+<?php
+
+namespace App\Enums;
+
+class Helper
+{
+}
+PHP);
+
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->outputDir.'/note.ts');
+        $this->assertFileDoesNotExist($this->outputDir.'/Helper.ts');
+
+        $indexFile = $this->outputDir.'/index.ts';
+        $this->assertFileExists($indexFile);
+
+        $indexContent = File::get($indexFile);
+        $this->assertStringNotContainsString('note', $indexContent);
+        $this->assertStringNotContainsString('Helper', $indexContent);
+    }
 }


### PR DESCRIPTION
## Summary
- add coverage to ensure the enum exporter skips non-enum files

## Testing
- `./vendor/bin/pint tests/Console/ExportEnumsCommandTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb06b99f4832588742b92c5446342