### PR TITLE
Handle declare statements and comments before namespace for enums

### DIFF
--- a/tests/Console/ExportEnumsCommandTest.php
+++ b/tests/Console/ExportEnumsCommandTest.php
@@ -43,7 +43,7 @@ PHP);
         File::put($this->enumDir.'/Billing/InvoiceStatus.php', <<<'PHP'
 <?php
 
-namespace App\Enums\Billing;
+    namespace App\Enums\Billing;
 
 enum InvoiceStatus: int
 {
@@ -132,5 +132,49 @@ PHP);
         $this->artisan('atlas:export-enums')->assertExitCode(0);
 
         $this->assertFileDoesNotExist($invoiceFile);
+    }
+
+    public function test_exports_enum_with_declare_and_comments_before_namespace(): void
+    {
+        File::put($this->enumDir.'/Billing/DeclaredInvoiceStatus.php', <<<'PHP'
+<?php
+declare(strict_types=1);
+
+// Example comment
+    namespace App\Enums\Billing;
+
+enum DeclaredInvoiceStatus: int
+{
+    case Paid = 1;
+    case Unpaid = 0;
+}
+PHP);
+
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $file = $this->outputDir.'/Billing/DeclaredInvoiceStatus.ts';
+        $this->assertFileExists($file);
+        $this->assertStringContainsString('export enum DeclaredInvoiceStatus', File::get($file));
+    }
+
+    public function test_exports_enum_with_comment_before_namespace(): void
+    {
+        File::put($this->enumDir.'/CommentStatus.php', <<<'PHP'
+<?php
+// Leading comment
+
+namespace App\Enums;
+
+enum CommentStatus: string
+{
+    case Draft = 'draft';
+}
+PHP);
+
+        $this->artisan('atlas:export-enums')->assertExitCode(0);
+
+        $file = $this->outputDir.'/CommentStatus.ts';
+        $this->assertFileExists($file);
+        $this->assertStringContainsString('export enum CommentStatus', File::get($file));
     }
 }


### PR DESCRIPTION
## Summary
- parse enum namespaces using PHP tokens to ignore declare statements, comments, and whitespace
- test enum exporting when files include `declare(strict_types=1);` and comments before the namespace

## Testing
- `vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb11e59e88325bcef14a84efb456f