### PR TITLE
docs: add pint formatting requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@ coding conventions and expectations for contributors of this repository.
 - Use PHP 8+ features with strict types and typed properties.
 - Follow PSR-12 formatting (enforced via Laravel Pint).
 - Write tests for new features and run `composer test` before committing.
+- Format code with `./vendor/bin/pint` before committing.


### PR DESCRIPTION
## Summary
- document running `./vendor/bin/pint` before committing

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb21ab1108325b40f198f43e2c099