### PR TITLE
docs: add documentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,9 @@ coding conventions and expectations for contributors of this repository.
 - Follow PSR-12 formatting (enforced via Laravel Pint).
 - Write tests for new features and run `composer test` before committing.
 - Format code with `./vendor/bin/pint` before committing.
+
+## Documentation
+- New or changed features must update relevant Markdown files in `docs/` and `README.md`, including examples when possible.
+- New features belong under `/docs/features/`.
+- Any new features or behavior changes must be reflected in the docs.
+- Documentation should start with a brief introduction, describe what the feature is and the problem it solves, then show how to use it via API descriptions and example usage.


### PR DESCRIPTION
## Summary
- add documentation guidelines for repo contributions

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb3fac6fc8325a575c9b33ad9770f