### PR TITLE
docs: streamline enum exporter guide

### DIFF
--- a/docs/features/enum-exporter.md
+++ b/docs/features/enum-exporter.md
@@ -1,28 +1,23 @@
 # Enum Exporter
 
-Export Laravel PHP enums to your Vue application so both back and front end share the same enum definitions.
+Sync Laravel PHP enums with Vue by generating matching TypeScript or JavaScript enums.
 
-## Optional Configuration
+## Configuration (optional)
 
-Publish the config if you need to customize export paths or format:
+Publish the config to change the output directory or file format:
 
 ```bash
 php artisan vendor:publish --tag=atlas-config
 ```
 
-## Export enums to Vue
-
-Run the exporter to generate TypeScript or JavaScript enum files:
+## Export enums
 
 ```bash
 php artisan atlas:export-enums
 ```
 
-## How it works
-
-The command scans the configured enum paths and writes matching files to `resources/js/enums` (overridable via config). Each PHP enum is converted into a corresponding TypeScript/JavaScript enum and re-exported through an index file for easy imports.
-
-If multiple enums share the same class name in different namespaces, the index file automatically aliases duplicates using their path segments to avoid export conflicts. Repeated segments that already appear in the class name are omitted to keep aliases concise:
+The command scans your configured enum paths and writes files to `resources/js/enums` by default. An `index.ts` file re-exports
+each enum for easy imports. When multiple enums share the same class name, the index aliases duplicates using namespace segments:
 
 ```ts
 // resources/js/enums/index.ts
@@ -30,7 +25,9 @@ export { ActionStatus } from './Action/ActionStatus';
 export { ActionStatus as ActionWorkerStatus } from './Action/Worker/ActionStatus';
 ```
 
-Define a PHP enum:
+## Example
+
+PHP enum:
 
 ```php
 namespace App\Enums;
@@ -42,27 +39,26 @@ enum UserStatus: string
 }
 ```
 
-After running the exporter the following file is generated:
-
-`resources/js/enums/UserStatus.ts`
+Generated TypeScript:
 
 ```ts
+// resources/js/enums/UserStatus.ts
 export enum UserStatus {
     ACTIVE = 'active',
     INACTIVE = 'inactive',
 }
 ```
 
-You can then compare data to enum values in Vue components:
+Use in Vue:
 
 ```vue
 <script setup lang="ts">
 import { UserStatus } from '@/enums';
 
 const user = ref({ status: 'active' });
-
 const isActive = computed(() => user.value.status === UserStatus.ACTIVE);
 </script>
 ```
 
 This keeps enum definitions synchronized across Laravel and Vue with full IDE support.
+


### PR DESCRIPTION
## Summary
- simplify enum exporter docs for Laravel and Vue
- explain configuration, export command, and aliasing of duplicate enums
- provide concise example of PHP enum and its Vue usage

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb4f8df888325a1bb4c4e07ee212f