### PR TITLE
docs: streamline inertia datatable docs

### DIFF
--- a/docs/features/inertia-data-table-options.md
+++ b/docs/features/inertia-data-table-options.md
@@ -1,19 +1,21 @@
 # Inertia DataTable Options
 
-The `InertiaDataTableOptions` trait helps controllers build datatable query options by combining defaults, request input, and optional session data. Filter values are type-cast using the `Caster` helper so they can be safely consumed by services and queries.
+`InertiaDataTableOptions` merges default datatable settings with request input
+and optional session data. Filter values are type-cast with the `Caster`
+helper so services can safely consume them.
 
 ## Returned Options
 
-`resolveIndexOptions` returns an array with these keys:
+`resolveIndexOptions` produces an array with:
 
-- `search` – free-text query used for filtering.
-- `filters` – associative array of typed filters.
-- `viewFields` – fields that should be visible in the table.
-- `perPage` – number of results per page.
-- `sortField` – column used to order results.
-- `sortOrder` – `1` for ascending or `-1` for descending order.
+- `search` – free-text filter
+- `filters` – typed filter values
+- `viewFields` – visible columns
+- `perPage` – results per page
+- `sortField` – column used for ordering
+- `sortOrder` – `1` asc, `-1` desc
 
-## Usage
+## Controller Example
 
 ```php
 use Atlas\Laravel\Http\Concerns\InertiaDataTableOptions;
@@ -24,9 +26,7 @@ class UsersController
 {
     use InertiaDataTableOptions;
 
-    protected array $filterCasts = [
-        'user_id' => 'int',
-    ];
+    protected array $filterCasts = ['user_id' => 'int'];
 
     protected array $indexDefaults = [
         'perPage' => 50,
@@ -46,13 +46,13 @@ class UsersController
 }
 ```
 
-- `$filterCasts` defines expected types for filter values and leverages `Caster` for conversion.
-- `$indexDefaults` provides fallback values for pagination and sorting.
-- Calling `resolveIndexOptions($request, true, 'users.index')` merges defaults with request data, persists them to the session, and returns the combined options for rendering.
+`$filterCasts` defines expected types for filters. `$indexDefaults` sets fallback
+pagination and sorting. `resolveIndexOptions` combines these with request data
+and optional session values.
 
-## Frontend Integration
+## Frontend
 
-Pass the resolved `$options` to your Inertia view. On the client side, the [`useDataTableOptions` composable](../ui/composables.md#usedatatableoptions) consumes the array and keeps query parameters synchronized with the server. Whenever a user searches, sorts, or filters, the composable issues an Inertia request with the updated options so both frontend and backend stay in sync.
+Pass `$options` to the view. The [`useDataTableOptions` composable](../ui/composables.md#usedatatableoptions) keeps query parameters in sync:
 
 ```vue
 <script setup>
@@ -64,13 +64,10 @@ const table = useDataTableOptions('users.index', props.options);
 </script>
 ```
 
-This pattern keeps controller methods lean while ensuring consistent datatable behavior across requests and a seamless experience between frontend and backend.
+## Custom Filters
 
-### Custom Filters
-
-The composable returns a reactive `filters` object. Bind UI inputs to it or
-update it programmatically and `useDataTableOptions` will automatically submit
-new requests whenever a filter changes.
+`useDataTableOptions` exposes a reactive `filters` object. Update it to trigger a
+new request automatically:
 
 ```vue
 <template>
@@ -88,13 +85,10 @@ import { usePage } from '@inertiajs/vue3';
 const { props } = usePage();
 const table = useDataTableOptions('users.index', props.options);
 
-// Filters can also be set directly in script
 table.form.filters.role = 'admin';
 </script>
 ```
 
-Any modification to `filters` triggers `fetchData` and resets row selection so
-the server and client remain in sync. Call `table.fetchData()` manually if you
-need to dispatch a request on demand (for example after clicking a submit
-button).
+Any filter change calls `fetchData` and clears row selection. Invoke
+`table.fetchData()` to refresh on demand.
 


### PR DESCRIPTION
## Summary
- simplify InertiaDataTableOptions docs
- clarify returned options and frontend usage

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb503d75083259696633b4b8219ac