### PR TITLE
Support common boolean string casts

### DIFF
--- a/docs/features/support.md
+++ b/docs/features/support.md
@@ -27,4 +27,6 @@ $cast = Caster::cast($data, $casts);
 // ['count' => 1, 'active' => true]
 ```
 
+Boolean casts recognize the strings `"true"`, `"false"`, `"1"`, `"0"`, `"yes"`, and `"no"` before falling back to PHP's default boolean casting.
+
 These helpers are designed to be lightweight and framework agnostic, making them easy to reuse across projects.

--- a/src/Support/Caster.php
+++ b/src/Support/Caster.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Atlas\Laravel\Support;
 
 use Illuminate\Support\Carbon;
@@ -37,12 +39,31 @@ class Caster
             'int', 'integer' => (int) $value,
             'float', 'double' => (float) $value,
             'string' => (string) $value,
-            'bool', 'boolean' => (bool) $value,
+            'bool', 'boolean' => self::castToBoolean($value),
             'array' => (array) $value,
             'datetime' => self::castToDateTime($value),
             'json' => self::castToJson($value),
             default => $value,
         };
+    }
+
+    /**
+     * Cast a value to boolean.
+     *
+     * @param  mixed  $value  The value to cast.
+     * @return bool The cast boolean value.
+     */
+    private static function castToBoolean(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return match (strtolower($value)) {
+                'true', '1', 'yes' => true,
+                'false', '0', 'no' => false,
+                default => (bool) $value,
+            };
+        }
+
+        return (bool) $value;
     }
 
     /**

--- a/tests/Support/CasterTest.php
+++ b/tests/Support/CasterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Atlas\Laravel\Tests\Support;
 
 use Atlas\Laravel\Support\Caster;
@@ -52,5 +54,35 @@ class CasterTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $result['metaObject']);
         $this->assertNull($result['invalidDate']);
         $this->assertNull($result['invalidJson']);
+    }
+
+    public function test_casts_boolean_strings(): void
+    {
+        $data = [
+            'true' => 'true',
+            'false' => 'false',
+            'one' => '1',
+            'zero' => '0',
+            'yes' => 'yes',
+            'no' => 'no',
+        ];
+
+        $casts = [
+            'true' => 'bool',
+            'false' => 'bool',
+            'one' => 'bool',
+            'zero' => 'bool',
+            'yes' => 'bool',
+            'no' => 'bool',
+        ];
+
+        $result = Caster::cast($data, $casts);
+
+        $this->assertTrue($result['true']);
+        $this->assertFalse($result['false']);
+        $this->assertTrue($result['one']);
+        $this->assertFalse($result['zero']);
+        $this->assertTrue($result['yes']);
+        $this->assertFalse($result['no']);
     }
 }


### PR DESCRIPTION
## Summary
- interpret string values like "true", "false", "1", "0", "yes", and "no" when casting to bool
- test boolean string casting
- document recognized boolean strings in Caster docs

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb66141008325b28743f46d39834d