### PR TITLE
docs: document generated enums in vue guide

### DIFF
--- a/docs/standards/vue-guide.md
+++ b/docs/standards/vue-guide.md
@@ -27,7 +27,7 @@ This document defines the structure and rules for building Vue 3 components usin
     │   └── components/
     │   └── composables/
     │   └── services/
-    │   └── enums/
+    │       └── enums/
     │   └── utils/
     ├── tests/
     │   └── components/
@@ -62,6 +62,8 @@ Organized into subfolders:
 
 - Optional layer for wrapping Inertia visits, API helpers, or uploaders.
 - Encapsulates external data interactions.
+- Generated enums live in `services/enums` and are created via `php artisan atlas:export-enums` (see
+  [Enum Exporter](../features/enum-exporter.md)).
 
 ### Utils
 


### PR DESCRIPTION
## Summary
- document enums directory nested under services in Vue guide
- reference enum exporter command for generating enums

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb6f07aa08325bdefb29544cecd0c