### PR TITLE
test: cover integer input for PhoneNumber::format

### DIFF
--- a/tests/Support/PhoneNumberTest.php
+++ b/tests/Support/PhoneNumberTest.php
@@ -17,6 +17,11 @@ class PhoneNumberTest extends TestCase
         $this->assertSame('(123) 456-7890', PhoneNumber::format('(123) 456-7890'));
     }
 
+    public function test_format_accepts_integer_input(): void
+    {
+        $this->assertSame('(123) 456-7890', PhoneNumber::format(1234567890));
+    }
+
     public function test_format_returns_null_for_empty_input(): void
     {
         $this->assertNull(PhoneNumber::format(null));


### PR DESCRIPTION
## Summary
- add test to ensure `PhoneNumber::format` accepts integer input

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb74010f48325b4a4644bdf1c29d6