### PR TITLE
Return null when phone number normalization fails

### DIFF
--- a/docs/features/support.md
+++ b/docs/features/support.md
@@ -4,13 +4,14 @@ Atlas Laravel ships with small utility classes under the `Atlas\Laravel\Support`
 
 ## PhoneNumber
 
-Format and normalize US phone numbers.
+Format and normalize US phone numbers. `PhoneNumber::format` returns `null` when the value can't be normalized.
 
 ```php
 use Atlas\Laravel\Support\PhoneNumber;
 
 PhoneNumber::format('1234567890'); // (123) 456-7890
 PhoneNumber::normalize('+1 (123) 456-7890'); // 1234567890
+PhoneNumber::format('123'); // null
 ```
 
 ## Caster

--- a/src/Support/PhoneNumber.php
+++ b/src/Support/PhoneNumber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Atlas\Laravel\Support;
 
 class PhoneNumber
@@ -8,7 +10,7 @@ class PhoneNumber
      * Formats a 10-digit US phone number to (XXX) XXX-XXXX format.
      *
      * @param  string|int|null  $phoneNumber  The raw phone number input
-     * @return string|null Formatted phone number or null if input is empty
+     * @return string|null Formatted phone number or null if input is empty or invalid
      */
     public static function format(null|int|string $phoneNumber): ?string
     {
@@ -18,10 +20,10 @@ class PhoneNumber
 
         $phoneNumber = (string) $phoneNumber;
 
-        $phoneNumber = self::normalize($phoneNumber) ?? $phoneNumber;
+        $phoneNumber = self::normalize($phoneNumber);
 
-        if (strlen($phoneNumber) !== 10) {
-            return $phoneNumber;
+        if ($phoneNumber === null) {
+            return null;
         }
 
         return '('.substr($phoneNumber, 0, 3).') '.

--- a/tests/Support/PhoneNumberTest.php
+++ b/tests/Support/PhoneNumberTest.php
@@ -27,6 +27,11 @@ class PhoneNumberTest extends TestCase
         $this->assertNull(PhoneNumber::format(null));
     }
 
+    public function test_format_returns_null_when_normalization_fails(): void
+    {
+        $this->assertNull(PhoneNumber::format('123'));
+    }
+
     public function test_normalize_strips_country_code_and_symbols(): void
     {
         $this->assertSame('1234567890', PhoneNumber::normalize('+1 (123) 456-7890'));


### PR DESCRIPTION
## Summary
- Ensure `PhoneNumber::format` returns `null` when normalization fails
- Document new `PhoneNumber::format` behavior in support helpers docs
- Test formatting fails gracefully on invalid numbers

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acb9ab324c83259b97d9426f852c3c