### PR TITLE
Clarify feature documentation policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ coding conventions and expectations for contributors of this repository.
 - Format code with `./vendor/bin/pint` before committing.
 
 ## Documentation
-- New or changed features must update relevant Markdown files in `docs/` and `README.md`, including examples when possible.
-- New features belong under `/docs/features/`.
+- Group feature docs by their domain under `/docs/features/`.
+- For feature improvements, update the domain-specific doc only; update `README.md` only when introducing a feature not already listed.
+- New or changed features must update relevant Markdown files in `docs/`, including examples when possible.
 - Any new features or behavior changes must be reflected in the docs.
 - Documentation should start with a brief introduction, describe what the feature is and the problem it solves, then show how to use it via API descriptions and example usage.


### PR DESCRIPTION
## Summary
- Clarify documentation guidelines in AGENTS.md
- Note that feature docs are grouped by domain
- Only update README for brand new features

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acbb0f35ec832599432d941737b176