### PR TITLE
feat: add docs sync command

### DIFF
--- a/config/atlas_docs.php
+++ b/config/atlas_docs.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'delete' => true,
+    'repos' => [
+        [
+            'repo' => 'atlasphp/atlas-laravel',
+            'paths' => [
+                [
+                    'path' => 'docs',
+                    'output' => 'docs/atlas/atlas-laravel',
+                ],
+            ],
+            'ignore' => ['README.md'],
+        ],
+        [
+            'repo' => 'atlasphp/atlas-cli',
+            'paths' => [
+                [
+                    'path' => 'docs',
+                    'output' => 'docs/atlas/atlas-cli',
+                ],
+            ],
+            'ignore' => [],
+        ],
+    ],
+];

--- a/docs/atlas/.gitignore
+++ b/docs/atlas/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/features/docs-sync.md
+++ b/docs/features/docs-sync.md
@@ -1,0 +1,33 @@
+# Documentation Sync
+
+This command pulls documentation from other Atlas repositories into the local project.
+
+## Usage
+
+Configure the repositories in `config/atlas_docs.php`:
+
+```php
+return [
+    'delete' => true,
+    'repos' => [
+        [
+            'repo' => 'atlasphp/atlas-laravel',
+            'paths' => [
+                ['path' => 'docs/components', 'output' => 'docs/ui'],
+                ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+            ],
+            'ignore' => ['ignore.md'],
+        ],
+    ],
+];
+```
+
+Run the sync:
+
+```bash
+php artisan atlas:sync-docs
+```
+
+Each defined `path` is copied from the source repository into its `output` directory. Directories are nested under the output path by their basename, while individual files are placed directly under the output. Any `AGENTS.md` found at the repository root is also written to each output directory. Files matching `ignore` patterns are skipped.
+
+Output directories are deleted before syncing to remove outdated files. Set `delete` to `false` globally or per repository to preserve existing files.

--- a/src/AtlasServiceProvider.php
+++ b/src/AtlasServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Atlas\Laravel;
 
 use Atlas\Laravel\Console\Commands\ExportEnumsCommand;
+use Atlas\Laravel\Console\Commands\SyncDocsCommand;
 use Illuminate\Support\ServiceProvider;
 
 class AtlasServiceProvider extends ServiceProvider
@@ -13,6 +14,7 @@ class AtlasServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/atlas_enums.php', 'atlas_enums');
+        $this->mergeConfigFrom(__DIR__.'/../config/atlas_docs.php', 'atlas_docs');
     }
 
     /**
@@ -22,11 +24,13 @@ class AtlasServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/atlas_enums.php' => config_path('atlas_enums.php'),
+            __DIR__.'/../config/atlas_docs.php' => config_path('atlas_docs.php'),
         ], 'atlas-config');
 
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ExportEnumsCommand::class,
+                SyncDocsCommand::class,
             ]);
         }
     }

--- a/src/Console/Commands/SyncDocsCommand.php
+++ b/src/Console/Commands/SyncDocsCommand.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlas\Laravel\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class SyncDocsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'atlas:sync-docs';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Sync documentation from Atlas repositories';
+
+    public function handle(): int
+    {
+        $repos = config('atlas_docs.repos', []);
+        $defaultDelete = config('atlas_docs.delete', true);
+        $deletedOutputs = [];
+
+        foreach ($repos as $repoConfig) {
+            $repo = $repoConfig['repo'] ?? null;
+            if (! $repo) {
+                $this->warn('Repository not configured.');
+
+                continue;
+            }
+
+            $paths = $repoConfig['paths'] ?? [];
+            if ($paths === []) {
+                $this->warn("No paths configured for {$repo}.");
+
+                continue;
+            }
+
+            $ignore = $repoConfig['ignore'] ?? [];
+            $includeAgents = $repoConfig['include_agents'] ?? true;
+            $delete = $repoConfig['delete'] ?? $defaultDelete;
+
+            $treeResponse = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])->get(
+                "https://api.github.com/repos/{$repo}/git/trees/HEAD",
+                ['recursive' => 1]
+            );
+
+            if ($treeResponse->failed()) {
+                $this->error("Failed to fetch file list for {$repo}");
+
+                continue;
+            }
+
+            $tree = $treeResponse->json('tree', []);
+
+            $agentsContent = null;
+            if ($includeAgents && collect($tree)->contains(fn ($item) => ($item['path'] ?? null) === 'AGENTS.md')) {
+                $agentsContent = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])
+                    ->get("https://raw.githubusercontent.com/{$repo}/HEAD/AGENTS.md")
+                    ->body();
+            }
+
+            foreach ($paths as $pathConfig) {
+                $source = trim($pathConfig['path'] ?? '', '/');
+                $output = $pathConfig['output'] ?? null;
+
+                if ($source === '' || $output === null) {
+                    $this->warn("Invalid path configuration for {$repo}.");
+
+                    continue;
+                }
+
+                $outputBase = base_path($output);
+
+                if ($delete && ! in_array($outputBase, $deletedOutputs, true)) {
+                    File::deleteDirectory($outputBase);
+                    File::delete($outputBase);
+                    $deletedOutputs[] = $outputBase;
+                }
+
+                File::ensureDirectoryExists($outputBase);
+
+                foreach ($tree as $item) {
+                    if (($item['type'] ?? '') !== 'blob') {
+                        continue;
+                    }
+
+                    $itemPath = $item['path'];
+
+                    if ($itemPath === $source) {
+                        $relative = basename($source);
+
+                        if ($this->shouldIgnore($relative, $ignore)) {
+                            continue;
+                        }
+
+                        $url = "https://raw.githubusercontent.com/{$repo}/HEAD/{$itemPath}";
+                        $contents = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])->get($url)->body();
+
+                        $destination = $outputBase.'/'.$relative;
+                        File::ensureDirectoryExists(dirname($destination));
+                        File::put($destination, $contents);
+                    } elseif (str_starts_with($itemPath, $source.'/')) {
+                        $relative = substr($itemPath, strlen($source) + 1);
+
+                        if ($this->shouldIgnore($relative, $ignore)) {
+                            continue;
+                        }
+
+                        $url = "https://raw.githubusercontent.com/{$repo}/HEAD/{$itemPath}";
+                        $contents = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])->get($url)->body();
+
+                        $destination = $outputBase.'/'.basename($source).'/'.$relative;
+                        File::ensureDirectoryExists(dirname($destination));
+                        File::put($destination, $contents);
+                    }
+                }
+
+                if ($agentsContent !== null) {
+                    File::put($outputBase.'/AGENTS.md', $agentsContent);
+                }
+            }
+
+            $this->info("Synced docs for {$repo}");
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function shouldIgnore(string $path, array $patterns): bool
+    {
+        foreach ($patterns as $pattern) {
+            if (Str::is($pattern, $path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Console/SyncDocsCommandTest.php
+++ b/tests/Console/SyncDocsCommandTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atlas\Laravel\Tests\Console;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Orchestra\Testbench\TestCase;
+
+class SyncDocsCommandTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [\Atlas\Laravel\AtlasServiceProvider::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::deleteDirectory(base_path('docs/ui'));
+        File::deleteDirectory(base_path('docs/atlas'));
+        File::ensureDirectoryExists(base_path('docs/ui'));
+        File::ensureDirectoryExists(base_path('docs/atlas'));
+    }
+
+    public function test_syncs_selected_paths_and_agents(): void
+    {
+        Http::fake([
+            'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/components/button.md', 'type' => 'blob'],
+                    ['path' => 'docs/components/ignore.md', 'type' => 'blob'],
+                    ['path' => 'docs/README.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/components/button.md' => Http::response('button', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/components/ignore.md' => Http::response('ignore', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
+            'https://api.github.com/repos/foo/baz/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/file.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/baz/HEAD/AGENTS.md' => Http::response('agents-baz', 200),
+            'https://raw.githubusercontent.com/foo/baz/HEAD/docs/file.md' => Http::response('file', 200),
+        ]);
+
+        config(['atlas_docs.repos' => [
+            [
+                'repo' => 'foo/bar',
+                'ignore' => ['ignore.md'],
+                'paths' => [
+                    ['path' => 'docs/components', 'output' => 'docs/ui'],
+                    ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+                ],
+            ],
+            [
+                'repo' => 'foo/baz',
+                'paths' => [
+                    ['path' => 'docs', 'output' => 'docs/atlas/baz'],
+                ],
+            ],
+        ]]);
+
+        $this->artisan('atlas:sync-docs')->assertExitCode(0);
+
+        $this->assertFileExists(base_path('docs/ui/AGENTS.md'));
+        $this->assertFileExists(base_path('docs/ui/components/button.md'));
+        $this->assertFileDoesNotExist(base_path('docs/ui/components/ignore.md'));
+        $this->assertFileExists(base_path('docs/ui/README.md'));
+
+        $this->assertFileExists(base_path('docs/atlas/baz/AGENTS.md'));
+        $this->assertFileExists(base_path('docs/atlas/baz/docs/file.md'));
+    }
+
+    public function test_deletes_existing_output_by_default(): void
+    {
+        Http::fake([
+            'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/README.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
+        ]);
+
+        File::put(base_path('docs/ui/old.md'), 'old');
+
+        config(['atlas_docs.repos' => [
+            [
+                'repo' => 'foo/bar',
+                'paths' => [
+                    ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+                ],
+            ],
+        ]]);
+
+        $this->artisan('atlas:sync-docs')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(base_path('docs/ui/old.md'));
+        $this->assertFileExists(base_path('docs/ui/README.md'));
+    }
+
+    public function test_can_disable_delete_in_config(): void
+    {
+        Http::fake([
+            'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/README.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
+        ]);
+
+        File::put(base_path('docs/ui/old.md'), 'old');
+
+        config(['atlas_docs.repos' => [
+            [
+                'repo' => 'foo/bar',
+                'delete' => false,
+                'paths' => [
+                    ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+                ],
+            ],
+        ]]);
+
+        $this->artisan('atlas:sync-docs')->assertExitCode(0);
+
+        $this->assertFileExists(base_path('docs/ui/old.md'));
+        $this->assertFileExists(base_path('docs/ui/README.md'));
+    }
+
+    public function test_can_disable_delete_globally(): void
+    {
+        Http::fake([
+            'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/README.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
+        ]);
+
+        File::put(base_path('docs/ui/old.md'), 'old');
+
+        config([
+            'atlas_docs.delete' => false,
+            'atlas_docs.repos' => [
+                [
+                    'repo' => 'foo/bar',
+                    'paths' => [
+                        ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->artisan('atlas:sync-docs')->assertExitCode(0);
+
+        $this->assertFileExists(base_path('docs/ui/old.md'));
+        $this->assertFileExists(base_path('docs/ui/README.md'));
+    }
+
+    public function test_repo_can_enable_delete_when_global_disabled(): void
+    {
+        Http::fake([
+            'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
+                'tree' => [
+                    ['path' => 'AGENTS.md', 'type' => 'blob'],
+                    ['path' => 'docs/README.md', 'type' => 'blob'],
+                ],
+            ], 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
+            'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
+        ]);
+
+        File::put(base_path('docs/ui/old.md'), 'old');
+
+        config([
+            'atlas_docs.delete' => false,
+            'atlas_docs.repos' => [
+                [
+                    'repo' => 'foo/bar',
+                    'delete' => true,
+                    'paths' => [
+                        ['path' => 'docs/README.md', 'output' => 'docs/ui'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->artisan('atlas:sync-docs')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist(base_path('docs/ui/old.md'));
+        $this->assertFileExists(base_path('docs/ui/README.md'));
+    }
+}


### PR DESCRIPTION
## Summary
- add `delete` config option to wipe docs outputs before syncing
- clear output directories when syncing docs respecting global or repo override
- document deletion behavior and include tests for enabling/disabling delete
- cover global delete config and repo-specific override with new tests

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acbd4da96c832593e358e8b81dfb2e