### PR TITLE
Remove AGENTS.md auto-sync from docs command

### DIFF
--- a/docs/features/docs-sync.md
+++ b/docs/features/docs-sync.md
@@ -28,6 +28,6 @@ Run the sync:
 php artisan atlas:sync-docs
 ```
 
-Each defined `path` is copied from the source repository into its `output` directory. Directories are nested under the output path by their basename, while individual files are placed directly under the output. Any `AGENTS.md` found at the repository root is also written to each output directory. Files matching `ignore` patterns are skipped.
+Each defined `path` is copied from the source repository into its `output` directory. Directories are nested under the output path by their basename, while individual files are placed directly under the output. Files matching `ignore` patterns are skipped.
 
 Output directories are deleted before syncing to remove outdated files. Set `delete` to `false` globally or per repository to preserve existing files.

--- a/src/Console/Commands/SyncDocsCommand.php
+++ b/src/Console/Commands/SyncDocsCommand.php
@@ -43,7 +43,6 @@ class SyncDocsCommand extends Command
             }
 
             $ignore = $repoConfig['ignore'] ?? [];
-            $includeAgents = $repoConfig['include_agents'] ?? true;
             $delete = $repoConfig['delete'] ?? $defaultDelete;
 
             $treeResponse = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])->get(
@@ -58,13 +57,6 @@ class SyncDocsCommand extends Command
             }
 
             $tree = $treeResponse->json('tree', []);
-
-            $agentsContent = null;
-            if ($includeAgents && collect($tree)->contains(fn ($item) => ($item['path'] ?? null) === 'AGENTS.md')) {
-                $agentsContent = Http::withHeaders(['User-Agent' => 'atlas-docs-sync'])
-                    ->get("https://raw.githubusercontent.com/{$repo}/HEAD/AGENTS.md")
-                    ->body();
-            }
 
             foreach ($paths as $pathConfig) {
                 $source = trim($pathConfig['path'] ?? '', '/');
@@ -120,10 +112,6 @@ class SyncDocsCommand extends Command
                         File::ensureDirectoryExists(dirname($destination));
                         File::put($destination, $contents);
                     }
-                }
-
-                if ($agentsContent !== null) {
-                    File::put($outputBase.'/AGENTS.md', $agentsContent);
                 }
             }
 

--- a/tests/Console/SyncDocsCommandTest.php
+++ b/tests/Console/SyncDocsCommandTest.php
@@ -25,28 +25,24 @@ class SyncDocsCommandTest extends TestCase
         File::ensureDirectoryExists(base_path('docs/atlas'));
     }
 
-    public function test_syncs_selected_paths_and_agents(): void
+    public function test_syncs_selected_paths(): void
     {
         Http::fake([
             'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/components/button.md', 'type' => 'blob'],
                     ['path' => 'docs/components/ignore.md', 'type' => 'blob'],
                     ['path' => 'docs/README.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/components/button.md' => Http::response('button', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/components/ignore.md' => Http::response('ignore', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
             'https://api.github.com/repos/foo/baz/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/file.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/baz/HEAD/AGENTS.md' => Http::response('agents-baz', 200),
             'https://raw.githubusercontent.com/foo/baz/HEAD/docs/file.md' => Http::response('file', 200),
         ]);
 
@@ -69,12 +65,10 @@ class SyncDocsCommandTest extends TestCase
 
         $this->artisan('atlas:sync-docs')->assertExitCode(0);
 
-        $this->assertFileExists(base_path('docs/ui/AGENTS.md'));
         $this->assertFileExists(base_path('docs/ui/components/button.md'));
         $this->assertFileDoesNotExist(base_path('docs/ui/components/ignore.md'));
         $this->assertFileExists(base_path('docs/ui/README.md'));
 
-        $this->assertFileExists(base_path('docs/atlas/baz/AGENTS.md'));
         $this->assertFileExists(base_path('docs/atlas/baz/docs/file.md'));
     }
 
@@ -83,11 +77,9 @@ class SyncDocsCommandTest extends TestCase
         Http::fake([
             'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/README.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
         ]);
 
@@ -113,11 +105,9 @@ class SyncDocsCommandTest extends TestCase
         Http::fake([
             'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/README.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
         ]);
 
@@ -144,11 +134,9 @@ class SyncDocsCommandTest extends TestCase
         Http::fake([
             'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/README.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
         ]);
 
@@ -177,11 +165,9 @@ class SyncDocsCommandTest extends TestCase
         Http::fake([
             'https://api.github.com/repos/foo/bar/git/trees/HEAD*' => Http::response([
                 'tree' => [
-                    ['path' => 'AGENTS.md', 'type' => 'blob'],
                     ['path' => 'docs/README.md', 'type' => 'blob'],
                 ],
             ], 200),
-            'https://raw.githubusercontent.com/foo/bar/HEAD/AGENTS.md' => Http::response('agents', 200),
             'https://raw.githubusercontent.com/foo/bar/HEAD/docs/README.md' => Http::response('readme', 200),
         ]);
 


### PR DESCRIPTION
## Summary
- remove root AGENTS.md fetching from docs sync
- update tests to only sync requested files
- clarify docs

## Testing
- `./vendor/bin/pint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_b_68acc691dc2083258c84734882c23428